### PR TITLE
Fix arrow position when table view is resized

### DIFF
--- a/ExpandableCell/ExpandableCell.swift
+++ b/ExpandableCell/ExpandableCell.swift
@@ -28,13 +28,18 @@ open class ExpandableCell: UITableViewCell {
     }
     
     func initView() {
-        let width = UIScreen.main.bounds.width
-        let height = self.frame.height
-        
-        arrowImageView = UIImageView(frame: CGRect(x: width - 54, y: (height - 11)/2, width: 22, height: 11))
+        arrowImageView = UIImageView()
         arrowImageView.image = UIImage(named: "expandableCell_arrow", in: Bundle(for: ExpandableCell.self), compatibleWith: nil)
         self.contentView.addSubview(arrowImageView)
-        
+    }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let width = self.bounds.width
+        let height = self.bounds.height
+
+        arrowImageView.frame = CGRect(x: width - 54, y: (height - 11)/2, width: 22, height: 11)
     }
     
     func open() {


### PR DESCRIPTION
This properly updates the position of the arrow icon when the table view is resized. This can be tested by rotating the device in the example project.