### PR TITLE
ExpandedHeight: invalid index crash

### DIFF
--- a/ExpandableCell/ExpandableProcessor.swift
+++ b/ExpandableCell/ExpandableProcessor.swift
@@ -147,7 +147,8 @@ class ExpandableProcessor {
     
     func expandedCell(at indexPath: IndexPath) -> UITableViewCell? {
         for expandableData in expandableDatas {
-            if let index = expandableData.expandedIndexPaths.index(of: indexPath) {
+            if let index = expandableData.expandedIndexPaths.index(of: indexPath),
+                index < expandableData.expandedCells.count {
                 return expandableData.expandedCells[index]
             }
         }

--- a/ExpandableCell/ExpandableProcessor.swift
+++ b/ExpandableCell/ExpandableProcessor.swift
@@ -157,7 +157,8 @@ class ExpandableProcessor {
     
     func expandedHeight(at indexPath: IndexPath) -> CGFloat? {
         for expandableData in expandableDatas {
-            if let index = expandableData.expandedIndexPaths.index(of: indexPath) {
+            if let index = expandableData.expandedIndexPaths.index(of: indexPath),
+                index < expandableData.expandedHeights.count {
                 return expandableData.expandedHeights[index]
             }
         }


### PR DESCRIPTION
Fixes a crash happening sometimes, due to invalid index, when calling `ExpandableProcessor.expandedHeight(at indexPath:)`