### PR TITLE
Adds new Expansion style

### DIFF
--- a/ExpandableCell/ExpandableProcessor.swift
+++ b/ExpandableCell/ExpandableProcessor.swift
@@ -84,6 +84,24 @@ class ExpandableProcessor {
         expandableDatasPerSection[indexPath.section] = expandableDatas
     }
     
+    func deleteAllIndexPathsInSection(_ section: Int) -> (expandedIndexPaths:[IndexPath], indexPaths: [IndexPath]) {
+        var expandedIndexPaths = [IndexPath]()
+        var indexPaths = [IndexPath]()
+        
+        if let expandableDataInSection = expandableDatasPerSection[section] {
+            for expandableData in expandableDataInSection {
+                indexPaths.append(expandableData.indexPath)
+                for expandedIndexPath in expandableData.expandedIndexPaths {
+                    expandedIndexPaths.append(expandedIndexPath)
+                }
+            }
+        }
+        
+        expandableDatasPerSection.removeValue(forKey: section)
+        
+        return (expandedIndexPaths, indexPaths)
+    }
+    
     func deleteAllIndexPaths() -> (expandedIndexPaths:[IndexPath], indexPaths: [IndexPath]) {
         var expandedIndexPaths = [IndexPath]()
         var indexPaths = [IndexPath]()

--- a/ExpandableCell/ExpandableTableView.swift
+++ b/ExpandableCell/ExpandableTableView.swift
@@ -53,10 +53,10 @@ extension ExpandableTableView: UITableViewDataSource, UITableViewDelegate {
         if !expandedData.isExpandedCell {
             delegate.expandableTableView(self, didSelectRowAt: indexPath)
             if expandableProcessor.isExpandable(at: indexPath) {
-                if self.expansionStyle == .single {
-                    closeAll()
-                }
                 if let cell = self.cellForRow(at: indexPath) {
+                    if self.expansionStyle == .single {
+                        closeAll()
+                    }
                     if let correctIndexPath = self.indexPath(for: cell) {
                         // Check if there are other rows expanded in section
                         if expandableProcessor.numberOfExpandedRowsInSection(section: correctIndexPath.section) == 0 {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Set required `ExpandableDelegate` method.
 | Property | Type | Explanation |
 | -------- | ---- | ----------- |
 | `animation` | `UITableViewRowAnimation` | Animation when open and close | 
-| `expansionStyle` | `ExpandableTableView.ExpansionStyle` | Select expansion type: single: One row at a time, multi: Any number of rows at a time| 
+| `expansionStyle` | `ExpandableTableView.ExpansionStyle` | Select expansion type:<br>**single** - one row at a time;<br>**singlePerSection** - one row at a time, per section;<br>**multi** - any number of rows at a time| 
 
 #### ExpandableTableView methods
 | Method | Explanation |


### PR DESCRIPTION
- Adds new `ExpansionStyle`: **`singlePerSection`**;
- Adapts existing code to handle new style.

**Notes**: 
1. This PR is based on PR #53 (where the initial idea for this new case came from);
2. Demo (_ExpandableCellDemo_) wasn't updated with a new button to test this new expansion style behaviour to avoid "overcrowding" the navigation bar with buttons. 
TL;DR: it can be easily tested by simply replacing the style (`ExpansionStyle.single`) currently set in method `ViewController.expandSingleButtonClicked(_:)` with `ExpansionStyle.singlePerSection`.